### PR TITLE
Actually use the [xyz]label information when plotting

### DIFF
--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -86,21 +86,34 @@ namespace gnup {
 
     void Cell::init (Comm *c)
     {
-        const char * set = "set %crange [%f:%f]\n";
+        const char * set_range = "set %crange [%f:%f]\n";
+        const char * set_label = "set %clabel \"%s\"\n";
 
         if (flags & RANGE_X) {
-            c->command(set, 'x', ranges.x.min, ranges.x.max);
+            c->command(set_range, 'x', ranges.x.min, ranges.x.max);
         }
         if (flags & RANGE_Y) {
-            c->command(set, 'y', ranges.y.min, ranges.y.max);
+            c->command(set_range, 'y', ranges.y.min, ranges.y.max);
         }
         if (flags & RANGE_Z) {
-            c->command(set, 'z', ranges.z.min, ranges.z.max);
+            c->command(set_range, 'z', ranges.z.min, ranges.z.max);
+        }
+
+        if (flags & LABEL_X) {
+            c->command(set_label, 'x', labels.x);
+        }
+        if (flags & LABEL_Y) {
+            c->command(set_label, 'y', labels.y);
+        }
+        if (flags & LABEL_Z) {
+            c->command(set_label, 'z', labels.z);
         }
 
         if (title != NULL) {
             c->command("set title \"%s\"\n", title);
         }
+
+
     }
 
     void Cell::setTrigger (Trigger *t)

--- a/src/tests/layout0.cpp
+++ b/src/tests/layout0.cpp
@@ -7,6 +7,8 @@ static const char* tale[] = {
     "set multiplot",
     "set size 0.500000,0.500000",
     "set origin 0.000000,0.000000",
+    "set xlabel \"First x axis\"",
+    "set ylabel \"First y axis\"",
     "set title \"First plot\"",
     "plot \"-\" title \"A plot\" with linespoints,"
         " \"-\" title \"Another plot\" with lines",
@@ -23,6 +25,8 @@ static const char* tale[] = {
     "1.000000 4.000000",
     "e",
     "set origin 0.500000,0.500000",
+    "set xlabel \"Second x axis\"",
+    "set ylabel \"Second y axis\"",
     "set title \"Second plot\"",
     "plot \"-\" title \"A plot\" with linespoints",
     "1.000000",
@@ -58,9 +62,13 @@ int main (int argc, char **argv)
     gp->addPlot(plot0, 0, 0);
     gp->addPlot(plot1, 0, 0);
     layout.getCell(0, 0).setTitle("First plot");
+    layout.getCell(0, 0).setXLabel("First x axis");
+    layout.getCell(0, 0).setYLabel("First y axis");
 
     gp->addPlot(plot0, 1, 1);
     layout.getCell(1, 1).setTitle("Second plot");
+    layout.getCell(1, 1).setXLabel("Second x axis");
+    layout.getCell(1, 1).setYLabel("Second y axis");
 
     plot0.setStyle(gnup::Plot::LINESPOINTS);
     plot0.addVector(0, 1);

--- a/src/tests/simpleplot.cpp
+++ b/src/tests/simpleplot.cpp
@@ -5,6 +5,8 @@
 #include "test_environ.hh"
 
 static const char* tale[] = {
+    "set xlabel \"x axis label\"",
+    "set ylabel \"y axis label\"",
     "plot \"-\" title \"A plot\" with linespoints",
     "1.000000",
     "2.000000",
@@ -12,6 +14,8 @@ static const char* tale[] = {
     "2.000000",
     "1.000000",
     "e",
+    "set xlabel \"x axis label\"",
+    "set ylabel \"y axis label\"",
     "plot \"-\" title \"A plot\" with linespoints",
     "1.000000",
     "2.000000",
@@ -39,6 +43,8 @@ int main (int argc, char **argv)
     gnup::GnuPlot *gp = new gnup::GnuPlot("testecho", io.params);
     gnup::Plot2D plot ("A plot", gnup::AUTO, gnup::DATA);
 
+    gp->getLayout().getCell(0,0).setXLabel("x axis label");
+    gp->getLayout().getCell(0,0).setYLabel("y axis label");
     gp->addPlot(plot);
     plot.setStyle(gnup::Plot::LINESPOINTS);
     plot.addVector(0, 1);


### PR DESCRIPTION
Hi Giovanni,

I intend to use your gnupplus library in a program and I missed the labels for the axes. As far as I could tell the code so far provides a way to set them in the Cell class, but it doesn't emit them to the gnuplot command stream.

Please feel free to apply the few lines from my "fork" back into yours.

Kind regards

Martin
